### PR TITLE
Pass local classloaders to JAXB and ServiceLoader

### DIFF
--- a/src/main/java/io/konik/InvoiceTransformer.java
+++ b/src/main/java/io/konik/InvoiceTransformer.java
@@ -57,7 +57,7 @@ public class InvoiceTransformer {
     */
    public InvoiceTransformer() {
       try {
-         this.jaxbContext = newInstance(KONIK_CONTEXT);
+         this.jaxbContext = newInstance(KONIK_CONTEXT, InvoiceTransformer.class.getClassLoader());
       } catch (JAXBException e) {
          throw new TransformationException("Could not instantiate JaxB Context", e);
       }

--- a/src/main/java/io/konik/PdfHandler.java
+++ b/src/main/java/io/konik/PdfHandler.java
@@ -71,7 +71,7 @@ public class PdfHandler {
     * If error is thrown check you have a Konik PDF Carriage on the classpath.
     */
    public PdfHandler() {
-      Iterator iterator = ServiceLoader.load(FileAppender.class).iterator();
+      Iterator iterator = ServiceLoader.load(FileAppender.class, PdfHandler.class.getClassLoader()).iterator();
       List<FileAppender> appenders = Lists.<FileAppender> newArrayList(iterator);
 
       if (appenders.isEmpty()) {
@@ -81,7 +81,7 @@ public class PdfHandler {
       Collections.sort(appenders, new FileAppenderPriorityComparator(Order.DESC));
 
       this.fileAppender = appenders.get(0);
-      this.fileExtractor = ServiceLoader.load(FileExtractor.class).iterator().next();
+      this.fileExtractor = ServiceLoader.load(FileExtractor.class, PdfHandler.class.getClassLoader()).iterator().next();
       this.transformer = new InvoiceTransformer();
    }
 


### PR DESCRIPTION
We'd like to use Konik in an OSGi environment (Eclipse), where each bundle has their own classloaders and package visibility is strictly enforced.

To allow for JAXB and ServiceLoader classes to live in seperate bundles that do not have a dependency of Konik, and therefore by default have no visibility of Konik's packages, Konik can pass its own classloader.